### PR TITLE
Notify Slack of new disputes

### DIFF
--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -154,6 +154,7 @@ module Pod
                     }]
                   }.to_json)
       rescue REST::Error
+        "RuboCop: If REST has problems POSTing to Slack, we don't care."
       end
     end
   end


### PR DESCRIPTION
@floere I need to give you `ENV['SLACK_DISPUTE_TOKEN']`

@kylef / @alloy check out `#integrations_test` to see how it looks. When satisfied, I will change the hook to point at the appropriate channel
