### PR TITLE
Prepare Trunk for moving shared DB code to Humus.

### DIFF
--- a/db/seeds/production.rb
+++ b/db/seeds/production.rb
@@ -3,13 +3,13 @@ require 'app/models/owner'
 module Pod
   module TrunkApp
     # This is an insider attribution to those that have worked on the initial app.
-    Owner.create(:email => 'eloy.de.enige@gmail.com', :name => 'Eloy Durán')
-    Owner.create(:email => 'florian.hanke@gmail.com', :name => 'Florian R. Hanke')
-    Owner.create(:email => 'manfred@fngtps.com',      :name => 'Manfred Stienstra')
-    Owner.create(:email => 'orta.therox@gmail.com',   :name => 'Orta Therox')
-    Owner.create(:email => 'inbox@kylefuller.co.uk',  :name => 'Kyle Fuller')
-    Owner.create(:email => 'fabiopelosin@gmail.com',  :name => 'Fabio Pelosin')
+    Owner.find_or_create(:email => 'eloy.de.enige@gmail.com', :name => 'Eloy Durán')
+    Owner.find_or_create(:email => 'florian.hanke@gmail.com', :name => 'Florian R. Hanke')
+    Owner.find_or_create(:email => 'manfred@fngtps.com',      :name => 'Manfred Stienstra')
+    Owner.find_or_create(:email => 'orta.therox@gmail.com',   :name => 'Orta Therox')
+    Owner.find_or_create(:email => 'inbox@kylefuller.co.uk',  :name => 'Kyle Fuller')
+    Owner.find_or_create(:email => 'fabiopelosin@gmail.com',  :name => 'Fabio Pelosin')
 
-    Owner.create(:email => Owner::UNCLAIMED_OWNER_EMAIL, :name => 'Unclaimed')
+    Owner.find_or_create(:email => Owner::UNCLAIMED_OWNER_EMAIL, :name => 'Unclaimed')
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,6 +23,8 @@ $LOAD_PATH.unshift File.expand_path('../../', __FILE__)
 require 'config/init'
 require 'app/controllers/app_controller'
 
+require 'db/seeds'
+
 def DB.test_safe_transaction(&block)
   DB.transaction(:savepoint => true, &block)
 end


### PR DESCRIPTION
I've added code such that production seeding can be done repeatedly. Also, seeding is run before each test.

This ensures that we can extract the migration code cleanly into CocoaPods/Humus and still run the trunk app without issues.

I am not perfectly sure if this is The Way To Go™ – let's discuss if necessary. Ping @alloy.