### PR TITLE
[PodsController] Disallow pushes from too old of a CocoaPods Version

### DIFF
--- a/spec/functional/api/pods_controller_spec.rb
+++ b/spec/functional/api/pods_controller_spec.rb
@@ -76,6 +76,15 @@ module Pod::TrunkApp
       last_response.status.should == 422
     end
 
+    it 'fails when the client CocoaPods version is lower than the minimum' do
+      lambda do
+        post '/', spec.to_json, 'User-Agent' => 'CocoaPods/0.1.0.pre.1'
+      end.should.not.change { Pod.count + PodVersion.count }
+
+      last_response.status.should == 422
+      json_response['error'].should.match /minimum CocoaPods version/
+    end
+
     it 'fails with a spec that does not pass a quick lint' do
       spec.name = nil
       spec.version = nil


### PR DESCRIPTION
Closes https://github.com/CocoaPods/trunk.cocoapods.org/issues/117.
Uses https://github.com/CocoaPods/cocoapods-trunk/commit/d63ce3be7def66ad48b0995038e7e3ac339b7c34, and will not raise an exception when no version is present in the header.

\c @floere @alloy @Keithbsmiley @orta 