### PR TITLE
@alloy =>  Only run existance validations for GitHub git sources

### DIFF
--- a/app/models/specification_wrapper.rb
+++ b/app/models/specification_wrapper.rb
@@ -71,6 +71,9 @@ module Pod
       end
 
       def validate_git
+        # We've had trouble with Heroku's git install
+        return true unless @specification.source[:git].include? 'github.com'
+
         ref = @specification.source[:tag] ||
           @specification.source[:commit] ||
           @specification.source[:branch] ||

--- a/app/models/specification_wrapper.rb
+++ b/app/models/specification_wrapper.rb
@@ -71,8 +71,9 @@ module Pod
       end
 
       def validate_git
-        # We've had trouble with Heroku's git install
-        return true unless @specification.source[:git].include? 'github.com'
+        # We've had trouble with Heroku's git install, see trunk.cocoapods.org/pull/141
+        url = @specification.source[:git]
+        return true unless url.include?('github.com') || url.include?('bitbucket.org')
 
         ref = @specification.source[:tag] ||
           @specification.source[:commit] ||

--- a/spec/functional/api/pods_controller_spec.rb
+++ b/spec/functional/api/pods_controller_spec.rb
@@ -238,6 +238,15 @@ module Pod::TrunkApp
       post '/', spec.to_json
     end
 
+    it 'uses git ls for a BitBucket git source' do
+      SpecificationWrapper.any_instance.expects(:system)
+        .with('git', 'ls-remote', 'https://bitbucket.org/technologyastronauts/oss_flounder.git', '1.2.0')
+        .returns(true)
+      spec.source = { :git => 'https://bitbucket.org/technologyastronauts/oss_flounder.git', :tag => '1.2.0' }
+
+      post '/', spec.to_json
+    end
+
     it 'does not not run git ls for a non-GitHub git source' do
       SpecificationWrapper.any_instance.expects(:system).never
       spec.source = { :git => 'https://orta.io/thingy.git', :tag => '0.1.2' }

--- a/spec/functional/api/pods_controller_spec.rb
+++ b/spec/functional/api/pods_controller_spec.rb
@@ -231,10 +231,16 @@ module Pod::TrunkApp
     #   post '/', spec.to_json
     # end
 
-    it 'uses git ls for a git source' do
+    it 'uses git ls for a GitHub git source' do
       SpecificationWrapper.any_instance.expects(:system)
         .with('git', 'ls-remote', 'https://github.com/AFNetworking/AFNetworking.git', '1.2.0')
         .returns(true)
+      post '/', spec.to_json
+    end
+
+    it 'does not not run git ls for a non-GitHub git source' do
+      SpecificationWrapper.any_instance.expects(:system).never
+      spec.source = { :git => 'https://orta.io/thingy.git', :tag => '0.1.2' }
       post '/', spec.to_json
     end
 


### PR DESCRIPTION
So, the heroku version of git on our dyno is an old build that isn't [built with openssl](https://opensource.ncsa.illinois.edu/confluence/questions/43515971). What ends up happening is that we can't rely on the the `git ls-remote` behavior to work as expected on non-GitHub hosted git instances. So to work around this, only GitHub sources get a check that they exist, for others it is presumed they know what they're doing.

![screen shot 2015-07-27 at 8 42 41 am](https://cloud.githubusercontent.com/assets/49038/8906317/9c6e4c70-343b-11e5-9f3d-ebefd93430b9.png)