### PR TITLE
Send confirmation emails from no-reply

### DIFF
--- a/app/models/owner.rb
+++ b/app/models/owner.rb
@@ -77,7 +77,7 @@ module Pod
 
         mail = Mail.new
         mail.charset = 'UTF-8'
-        mail.from    = 'info@cocoapods.org'
+        mail.from    = 'no-reply@cocoapods.org'
         mail.to      = email
         mail.subject = @was_created ? '[CocoaPods] Confirm your registration.' : '[CocoaPods] Confirm your session.'
         mail.body    = ERB.new(File.read(File.join(ROOT, 'app/views/mailer/create_session.erb'))).result(binding)


### PR DESCRIPTION
Lots of people use email addresses with trunk which auto-respond and spam us. Some also reply/forward the mail and leave us CC-ed.

Therefore moving to `no-reply@` to stop the spam hitting us.

Closes #140

/cc @alloy 