### PR TITLE
Require authentication to change name

### DIFF
--- a/app/controllers/api/sessions_controller.rb
+++ b/app/controllers/api/sessions_controller.rb
@@ -9,11 +9,12 @@ module Pod
     class SessionsController < APIController
       post '/', :requires_owner => false do
         owner_params = JSON.parse(request.body.read)
+        authorized = @owner.present?
+
         DB.test_safe_transaction do
           owner_email, owner_name, session_description = owner_params.values_at('email', 'name', 'description')
           owner = Owner.find_or_initialize_by_email_and_name(owner_email, owner_name).tap do |o|
-            # only update name of an existing user if authorized
-            o.name = owner_name if @owner && owner_name.present?
+            o.name = owner_name if authorized && owner_name.present?
             o.save
           end
 

--- a/app/controllers/api/sessions_controller.rb
+++ b/app/controllers/api/sessions_controller.rb
@@ -11,7 +11,11 @@ module Pod
         owner_params = JSON.parse(request.body.read)
         DB.test_safe_transaction do
           owner_email, owner_name, session_description = owner_params.values_at('email', 'name', 'description')
-          owner = Owner.find_or_create_by_email_and_update_name(owner_email, owner_name)
+          owner = Owner.find_or_initialize_by_email_and_name(owner_email, owner_name).tap do |o|
+            # only update name of an existing user if authorized
+            o.name = owner_name if @owner && owner_name.present?
+            o.save
+          end
 
           url_template = "#{request.scheme}://#{request.host_with_port}/sessions/verify/%s"
           session = owner.create_session!(request.ip, url_template, session_description)

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -81,7 +81,7 @@ module Pod
 
       def find_owner
         owner_email, owner_name = params[:owner].values_at('email', 'name')
-        @owner = Owner.find_or_initialize_by_email_and_update_name(owner_email, owner_name)
+        @owner = Owner.find_or_initialize_by_email_and_name(owner_email, owner_name)
       end
 
       def find_pods

--- a/app/models/owner.rb
+++ b/app/models/owner.rb
@@ -28,19 +28,8 @@ module Pod
         first(:email => normalize_email(email))
       end
 
-      def self.find_or_initialize_by_email_and_update_name(email, name)
-        if owner = Owner.find_by_email(email)
-          owner.name = name unless name.blank?
-          owner
-        else
-          Owner.new(:email => email, :name => name)
-        end
-      end
-
-      def self.find_or_create_by_email_and_update_name(email, name)
-        owner = find_or_initialize_by_email_and_update_name(email, name)
-        owner.save_changes(:raise_on_save_failure => true)
-        owner
+      def self.find_or_initialize_by_email_and_name(email, name)
+        Owner.find_by_email(email) || Owner.new(:email => email, :name => name)
       end
 
       def public_attributes

--- a/spec/functional/api/sessions_controller_spec.rb
+++ b/spec/functional/api/sessions_controller_spec.rb
@@ -73,9 +73,15 @@ module Pod::TrunkApp
     end
 
     it "updates the owner's name in case it is specified on subsequent registrations" do
+      sign_in!
+      post '/', { 'email' => @owner.email, 'name' => 'Changed' }.to_json
+      @owner.reload.name.should == 'Changed'
+    end
+
+    it "does not update the owner's name for unauthenticated users" do
       owner = Owner.create(:email => @email, :name => @name)
       post '/', { 'email' => @email, 'name' => 'Changed' }.to_json
-      owner.reload.name.should == 'Changed'
+      owner.reload.name.should == @name
     end
 
     it 'does not create a new session in case emailing raises an error' do

--- a/spec/functional/claims_controller_spec.rb
+++ b/spec/functional/claims_controller_spec.rb
@@ -41,12 +41,10 @@ module Pod::TrunkApp
       @pod.reload.owners.should == [owner]
     end
 
-    it 'finds an existing owner and updates its name if specified' do
+    it 'finds an existing owner and doesn\'t update its name' do
       owner = Owner.create(:email => 'appie@example.com', :name => 'Appie Duran')
-      post '/', :owner => { :email => 'appie@example.com', :name => ' ' }, :pods => ['AFNetworking']
-      owner.reload.name.should == 'Appie Duran'
       post '/', :owner => { :email => 'appie@example.com', :name => 'Appiepocalypse' }, :pods => ['AFNetworking']
-      owner.reload.name.should == 'Appiepocalypse'
+      owner.reload.name.should == 'Appie Duran'
     end
 
     it 'does not assign a pod that has already been claimed' do

--- a/spec/functional/claims_controller_spec.rb
+++ b/spec/functional/claims_controller_spec.rb
@@ -41,7 +41,7 @@ module Pod::TrunkApp
       @pod.reload.owners.should == [owner]
     end
 
-    it 'finds an existing owner and doesn\'t update its name' do
+    it "finds an existing owner and doesn't update its name" do
       owner = Owner.create(:email => 'appie@example.com', :name => 'Appie Duran')
       post '/', :owner => { :email => 'appie@example.com', :name => 'Appiepocalypse' }, :pods => ['AFNetworking']
       owner.reload.name.should == 'Appie Duran'

--- a/spec/unit/owner_spec.rb
+++ b/spec/unit/owner_spec.rb
@@ -2,11 +2,9 @@ require File.expand_path('../../spec_helper', __FILE__)
 
 module Pod::TrunkApp
   describe Owner do
-    it 'creates an owner' do
+    it 'initializes an owner' do
       owner = nil
-      lambda do
-        owner = Owner.find_or_create_by_email_and_update_name(' appie@example.com ', ' Appie ')
-      end.should.change { Owner.count }
+      owner = Owner.find_or_initialize_by_email_and_name(' appie@example.com ', ' Appie ')
       owner.email.should == 'appie@example.com'
       owner.name.should == 'Appie'
     end
@@ -17,17 +15,8 @@ module Pod::TrunkApp
 
     it 'finds an existing owner by email' do
       lambda do
-        Owner.find_or_create_by_email_and_update_name(@owner.email, '').should == @owner
+        Owner.find_or_initialize_by_email_and_name(@owner.email, '').should == @owner
       end.should.not.change { Owner.count }
-    end
-
-    it "updates an owner's name if specified" do
-      Owner.find_or_create_by_email_and_update_name(@owner.email, nil)
-      @owner.reload.name.should == 'Jenny'
-      Owner.find_or_create_by_email_and_update_name(@owner.email, ' ')
-      @owner.reload.name.should == 'Jenny'
-      Owner.find_or_create_by_email_and_update_name(@owner.email, ' Penny ')
-      @owner.reload.name.should == 'Penny'
     end
 
     describe 'concerning validations' do


### PR DESCRIPTION
While this isn't a big security issue, it still allows anyone to
change the name of a Pod owner (if you know their e-mail
address).

This also makes sure that "If you did not request this
you do not need to take any further action" is correct -
before this fix it should read "If you did not request this
you must still fix your name".