### PR TITLE
Redirects to the thanks page could come with no  already_claimed param

### DIFF
--- a/app/views/claims/thanks.slim
+++ b/app/views/claims/thanks.slim
@@ -11,6 +11,5 @@ ruby:
 - else
   p All of your choosen Pods are already claimed.
 
-- unless params[:already_claimed] == ['']
+- unless params[:already_claimed] == [''] || params[:already_claimed] == nil
   p The following #{params[:already_claimed].size == 1 ? 'pod has' : 'pods have'} already been claimed: #{params[:already_claimed].to_sentence}. If you disagree with this please <a href="#{url("/disputes/new?#{{ :claimer_email => params[:claimer_email], :pods => params[:already_claimed] }.to_query}")}">file a dispute</a>.
-


### PR DESCRIPTION
Redirects to the thanks page, can look like `claims/thanks?claimer_email=mail%40gmail.com&successfully_claimed%5B%5D=NimbusKit-Basics"` - which doesn't include a `already_claimed` param. 

The thanks message would crash out because it's nil. Now it won't. 