### PR TITLE
[WIP] Deletion Support

### DIFF
--- a/app/controllers/api/pods_controller.rb
+++ b/app/controllers/api/pods_controller.rb
@@ -211,27 +211,7 @@ module Pod
         end
 
         response = version.delete!(@owner)
-        if response(&:success?)
-          redirect pod.versions.last.resource_path
-        elsif response(&:failed_on_our_side?)
-          throw_internal_server_error!
-        elsif response(&:failed_on_their_side?)
-          # In case of a 5xx at GitHub’s side, this might not mean the commit
-          # didn’t get created, it can also indicate an error occurred while
-          # rendering the response, hence asking for some patience in case we
-          # still update the PodVersion with a new Commit from the GitHub
-          # post-commit hook.
-          #
-          # TODO: Ask GitHub if they have some form of transaction system in
-          # place that rolls back a commit in case an error occurs during
-          # response rendering.
-          json_error(500, 'An error occurred on GitHub’s side. Please check GitHub’s status at ' \
-                          'https://status.github.com and try again later in case the pod is ' \
-                          'still not deleted.')
-        elsif responses.any(&:failed_due_to_timeout?)
-          json_error(504, 'Calling the GitHub commit API timed out. Please check GitHub’s ' \
-                          'status at https://status.github.com and try again later.')
-        end
+        json_message(200, [{version.name => 'deleted'}]) if verify_github_responses!(response)
       end
 
       patch '/:name/owners', :requires_owner => true do

--- a/app/controllers/api/pods_controller.rb
+++ b/app/controllers/api/pods_controller.rb
@@ -211,7 +211,7 @@ module Pod
         end
 
         response = version.delete!(@owner)
-        json_message(200, [{version.name => 'deleted'}]) if verify_github_responses!(response)
+        json_message(200, [{ version.name => 'deleted' }]) if verify_github_responses!(response)
       end
 
       patch '/:name/owners', :requires_owner => true do

--- a/app/controllers/api/pods_controller.rb
+++ b/app/controllers/api/pods_controller.rb
@@ -197,6 +197,43 @@ module Pod
         redirect pod.versions.last.resource_path if verify_github_responses!(responses)
       end
 
+      delete '/:name/:version', :requires_owner => true do
+        pod = Pod.find_by_name_and_owner(params[:name], @owner) do
+          json_error(403, 'You are not allowed to delete this pod.')
+        end
+        unless pod
+          json_error(404, 'No pod found with the specified name.')
+        end
+
+        version = pod.versions_dataset.where(:name => params[:version]).first
+        unless version
+          json_error(404, 'No pod version found with the specified version.')
+        end
+
+        response = version.delete!(@owner)
+        if response(&:success?)
+          redirect pod.versions.last.resource_path
+        elsif response(&:failed_on_our_side?)
+          throw_internal_server_error!
+        elsif response(&:failed_on_their_side?)
+          # In case of a 5xx at GitHub’s side, this might not mean the commit
+          # didn’t get created, it can also indicate an error occurred while
+          # rendering the response, hence asking for some patience in case we
+          # still update the PodVersion with a new Commit from the GitHub
+          # post-commit hook.
+          #
+          # TODO: Ask GitHub if they have some form of transaction system in
+          # place that rolls back a commit in case an error occurs during
+          # response rendering.
+          json_error(500, 'An error occurred on GitHub’s side. Please check GitHub’s status at ' \
+                          'https://status.github.com and try again later in case the pod is ' \
+                          'still not deleted.')
+        elsif responses.any(&:failed_due_to_timeout?)
+          json_error(504, 'Calling the GitHub commit API timed out. Please check GitHub’s ' \
+                          'status at https://status.github.com and try again later.')
+        end
+      end
+
       patch '/:name/owners', :requires_owner => true do
         pod = Pod.find_by_name_and_owner(params[:name], @owner) do
           json_error(403, 'You are not allowed to add owners to this pod.')

--- a/app/models/pod_version.rb
+++ b/app/models/pod_version.rb
@@ -96,6 +96,10 @@ module Pod
         push!(committer, spec.to_pretty_json, 'Deprecate')
       end
 
+      def delete!(committer)
+        PushJob.new(self, committer, nil, 'Delete').push!
+      end
+
       protected
 
       UNIQUE_VERSION = [:pod_id, :name]

--- a/app/models/pod_version.rb
+++ b/app/models/pod_version.rb
@@ -74,9 +74,9 @@ module Pod
       end
 
       def push!(committer, specification_data, change_type)
-        update(:deleted => false)
         response = PushJob.new(self, committer, specification_data, change_type).push!
         if response.success?
+          update(:deleted => specification_data.nil?)
           add_commit(:committer => committer, :sha => response.commit_sha, :specification_data => specification_data)
           pod.add_owner(committer) if pod.owners.empty?
         end
@@ -97,7 +97,8 @@ module Pod
       end
 
       def delete!(committer)
-        PushJob.new(self, committer, nil, 'Delete').push!
+        return if deleted?
+        push!(committer, nil, 'Delete')
       end
 
       protected

--- a/app/models/push_job.rb
+++ b/app/models/push_job.rb
@@ -21,13 +21,7 @@ module Pod
         log(:info, 'initiated', committer, specification_data)
 
         response, duration = measure_duration do
-          self.class.github.create_new_commit(
-            pod_version.destination_path,
-            specification_data,
-            commit_message,
-            committer.name,
-            committer.email
-          )
+          perform_action
         end
 
         log_response(response, committer, duration)
@@ -40,6 +34,27 @@ module Pod
       end
 
       protected
+
+      def perform_action
+        if job_type == 'Add'
+          return self.class.github.create_new_commit(
+            pod_version.destination_path,
+            specification_data,
+            commit_message,
+            committer.name,
+            committer.email
+          )
+        end
+
+        if job_type == 'Delete'
+          return self.class.github.delete_file_at_path(
+            pod_version.destination_path,
+            commit_message,
+            committer.name,
+            committer.email
+          )
+        end
+      end
 
       def log_response(response, committer, duration)
         if response.success?

--- a/app/models/push_job.rb
+++ b/app/models/push_job.rb
@@ -25,8 +25,7 @@ module Pod
         end
 
         log_response(response, committer, duration)
-        return response
-
+        response
       rescue Object => error
         message = "failed with error: #{error.message}."
         log(:error, message, committer, error.backtrace.join("\n\t\t"))
@@ -36,23 +35,24 @@ module Pod
       protected
 
       def perform_action
-        if job_type == 'Add'
-          return self.class.github.create_new_commit(
+        case job_type
+        when 'Add', 'Deprecate'
+          self.class.github.create_new_commit(
             pod_version.destination_path,
             specification_data,
             commit_message,
             committer.name,
             committer.email
           )
-        end
-
-        if job_type == 'Delete'
-          return self.class.github.delete_file_at_path(
+        when 'Delete'
+          self.class.github.delete_file_at_path(
             pod_version.destination_path,
             commit_message,
             committer.name,
             committer.email
           )
+        else
+          raise "Unknown push job type: #{job_type}"
         end
       end
 

--- a/spec/spec_helper/commit_response.rb
+++ b/spec/spec_helper/commit_response.rb
@@ -4,7 +4,7 @@ module SpecHelpers
       unless block
         block = lambda { REST::Response.new(status, {}, body) }
       end
-      Pod::TrunkApp::GitHub::CreateCommitResponse.new(&block)
+      Pod::TrunkApp::GitHub::CommitResponse.new(&block)
     end
   end
 end

--- a/spec/unit/github_spec.rb
+++ b/spec/unit/github_spec.rb
@@ -23,7 +23,7 @@ module Pod::TrunkApp
     it 'creates a new commit' do
       # Capture the args so we can assert on them after the call.
       args = nil
-      REST::Request.stubs(:perform).with do |method, url, body, headers, auth|
+      REST::Request.stubs(:perform).with do |_method, url, body, headers, auth|
         args = [url.to_s, body, headers, auth]
       end.returns(fixture_response('create_new_commit'))
 

--- a/spec/unit/github_spec.rb
+++ b/spec/unit/github_spec.rb
@@ -23,8 +23,8 @@ module Pod::TrunkApp
     it 'creates a new commit' do
       # Capture the args so we can assert on them after the call.
       args = nil
-      REST.stubs(:put).with do |url, body, headers, auth|
-        args = [url, body, headers, auth]
+      REST::Request.stubs(:perform).with do |method, url, body, headers, auth|
+        args = [url.to_s, body, headers, auth]
       end.returns(fixture_response('create_new_commit'))
 
       response = @github.create_new_commit(DESTINATION_PATH,


### PR DESCRIPTION
Note: I've aimed this at the deprecation branch #130  so that the diff is on-point.

I've added support for deleting a single version, I'm not sure that I'd like an easy "delete all versions of my pods" feature, if you're going to break something that much, you should work for it. So it only does it on a single version. Opening it up to ways to deal with some of the duplication I'm seeing? 

Notably the response handling is the same in three routes now, and I'm not too sold on the `if`s against the type in the PushJob.