### PR TITLE
Use a fork of nap that allows for HTTP DELETEs to support a content body

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,10 @@ source 'https://rubygems.org'
 ruby File.read(File.join(File.dirname(__FILE__), '.ruby-version')).chomp
 
 gem 'activesupport'
+
+# Temporary until https://github.com/Fingertips/nap/pull/11 is merged / released
+gem 'nap', :git => "https://github.com/orta/nap/", :branch => "delete_body"
+
 gem 'cocoapods-core', '>= 0.38.0.beta.1'
 gem 'tobias-sinatra-url-for'
 gem 'json', '~> 1.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,13 @@ GIT
   specs:
     peiji-san (1.2.0)
 
+GIT
+  remote: https://github.com/orta/nap/
+  revision: e3e94bb43a93935c7845b74cb323f0682891bcf1
+  branch: delete_body
+  specs:
+    nap (1.0.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -52,7 +59,6 @@ GEM
     mocha-on-bacon (0.2.2)
       mocha (>= 0.13.0)
     multi_json (1.10.1)
-    nap (1.0.0)
     newrelic_rpm (3.8.1.221)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
@@ -136,6 +142,7 @@ DEPENDENCIES
   kicker
   mail
   mocha-on-bacon
+  nap!
   newrelic_rpm
   nokogiri
   peiji-san!


### PR DESCRIPTION
I was surprised to find delete not working

```
2016-01-27T06:50:34.906339+00:00 heroku[router]: at=info method=DELETE path="/api/v1/pods/OrtaDeletePodTest/0.1.1" host=trunk.cocoapods.org request_id=f47a9c82-fff3-4afb-a73c-0f93dd3f8c2c fwd="95.146.99.151" dyno=web.1 connect=0ms service=319ms status=500 bytes=368
2016-01-27T06:50:34.834723+00:00 app[web.1]: I, [2016-01-27T06:50:34.834488 #3]  INFO -- : (0.001888s) INSERT INTO "log_messages" ("reference", "level", "message", "owner_id", "data", "pod_version_id", "created_at") VALUES ('PushJob with temporary ID: 70198652823980', 'error', 'Push for `OrtaDeletePodTest 0.1.1'' failed with HTTP error `422'' on our side (0.187984955 s).', 4, '{"message":"Invalid request.\n\n\"message\", \"sha\" weren''t supplied.","documentation_url":"https://developer.github.com/v3/repos/contents/"}', 67187, '2016-01-27 06:50:34.831720+0000') RETURNING *
```

so I looked into nap, and found that it doesn't send the body of a request. [PR sent](https://github.com/Fingertips/nap/pull/11), and this uses my fork.