### PR TITLE
Add support for responding to ACME requests inside trunk

### DIFF
--- a/app/controllers/app_controller.rb
+++ b/app/controllers/app_controller.rb
@@ -59,6 +59,7 @@ require 'app/controllers/session_verification_controller'
 require 'app/controllers/hooks_controller'
 require 'app/controllers/manage_controller'
 require 'app/controllers/assets_controller'
+require 'app/controllers/letsencrypt_controller'
 
 # TODO: Temporary controller while we transition to the trunk app.
 require 'app/controllers/claims_controller'
@@ -74,6 +75,7 @@ module Pod
       '/hooks'           => HooksController,
       '/manage'          => ManageController,
       '/assets'          => AssetsController,
+      '/.well-known'     => LetsEncryptController,
 
       # TODO: Temporary routes while we transition to the trunk app.
       '/claims'          => ClaimsController,

--- a/app/controllers/letsencrypt_controller.rb
+++ b/app/controllers/letsencrypt_controller.rb
@@ -1,0 +1,42 @@
+require 'app/controllers/app_controller'
+
+module Pod
+  module TrunkApp
+    # Relates to our Sabayon ( https://github.com/dmathieu/sabayon ) instance
+    # located at https://dashboard.heroku.com/apps/cocoapods-letsencrypt-sabayon/
+    #
+    # Sabayon will set up SSL cert for us, to do this, we have to prove we own the domain
+    # so LetsEncrypt asks for you to respond to a specific route.
+    # Sabayon will set environment vars on trunk, which will trigger a restart, this
+    # means at this point we can look inside our ENV vars and respond to the specific
+    # request that LetsEncrypt wants.
+    #
+    # This class is a modified version of the Rack example in the README
+    # https://github.com/dmathieu/sabayon#ruby-apps
+    #
+    class LetsEncryptController < AppController
+      configure :development do
+        register Sinatra::Reloader
+      end
+
+      get '/acme-challenge/:token' do
+        data = []
+        if ENV['ACME_KEY'] && ENV['ACME_TOKEN']
+          data << { :key => ENV['ACME_KEY'], :token => ENV['ACME_TOKEN'] }
+        else
+          ENV.each do |k, v|
+            if digit = k.match(/^ACME_KEY_([0-9]+)/)
+              index = digit[1]
+              data << { :key => v, :token => ENV["ACME_TOKEN_#{index}"] }
+            end
+          end
+        end
+
+        contract = data.find { |couplet| params[:token] == couplet[:token] }
+        return [200, { 'Content-Type' => 'text/plain' }, [contract[:key]]] if contract
+
+        error 404
+      end
+    end
+  end
+end

--- a/spec/functional/letsencrypt_controller_spec.rb
+++ b/spec/functional/letsencrypt_controller_spec.rb
@@ -1,0 +1,25 @@
+require File.expand_path('../../spec_helper', __FILE__)
+
+ENV['ACME_KEY_1']   = '123sadaf2342rfsdf'
+ENV['ACME_TOKEN_1'] = 'fkjsdbfnkjnk354nrfwegsdfg'
+
+module Pod::TrunkApp
+  describe LetsEncryptController do
+    test_controller! LetsEncryptController
+
+    # This controller is scoped to "/.well-known/" inside the app router
+
+    it 'handles ACME responses using known environment vars' do
+      get 'https://example.org/acme-challenge/' + ENV['ACME_TOKEN_1']
+      last_response.should.be.ok
+      last_response.body.should == ENV['ACME_KEY_1']
+      last_response.headers['Content-Type'].should == 'text/plain'
+    end
+
+    it '404s for responses without known environment vars' do
+      get 'https://example.org/acme-challenge/orta'
+      last_response.status.should == 404
+      last_response.body.should == ''
+    end
+  end
+end


### PR DESCRIPTION
LetsEncrypt needs Trunk to respond to requests from their servers in order to verify that we are who we say we are. This adds the ability for [Sabayon](https://github.com/dmathieu/sabayon#ruby-apps) to set ENV vars in our environment, and for trunk to respond to them.

Requests look like `http://sub.domain.eu/.well-known/acme-challenge/HPdGXEC2XEMFfbgpDxo49MNBFSmzYREn2i1U1lsEBDg` 

More details and links inside the comments in the source code.