### PR TITLE
Improve the error messaging for when we close trunk

### DIFF
--- a/app/controllers/api/pods_controller.rb
+++ b/app/controllers/api/pods_controller.rb
@@ -97,11 +97,8 @@ module Pod
 
       post '/', :requires_owner => true do
         unless ENV['TRUNK_APP_PUSH_ALLOWED'] == 'true'
-          json_error(503, 'Push access is currently disabled while we allow ' \
-                          'for owners to claim their Pods. Please read our ' \
-                          'blog posts: ' \
-                          'http://blog.cocoapods.org/CocoaPods-Trunk/ and ' \
-                          'http://blog.cocoapods.org/Claim-Your-Pods/')
+          json_error(503, 'We have closed pushing to CocoaPods trunk' \
+                          ', please see https://twitter.com/CocoaPods.org for details')
         end
 
         if version = %r{CocoaPods/([0-9a-z\.]+)}i.match(env['User-Agent'])

--- a/spec/functional/api/pods_controller_spec.rb
+++ b/spec/functional/api/pods_controller_spec.rb
@@ -61,7 +61,7 @@ module Pod::TrunkApp
             post '/', spec.to_json
           end.should.not.change { Pod.count + PodVersion.count }
           last_response.status.should == 503
-          json_response['error'].should.match /Push access is currently disabled/
+          json_response['error'].should.match /We have closed pushing to CocoaPods trunk/
         end
       ensure
         ENV['TRUNK_APP_PUSH_ALLOWED'] = 'true'


### PR DESCRIPTION
Currently closed while I figure out what's up with these responses 

```
{"message":"refs/heads/master is at d4aa4957329f39a05025d04d9d60969193c1c31a but expected fdb943a055924b26c70117a89d90000876afe3b2","documentation_url":"https://developer.github.com/v3/repos/contents/"}'
```