### PR TITLE
Redirect to unsettled disputes instead of messages

### DIFF
--- a/app/controllers/manage_controller.rb
+++ b/app/controllers/manage_controller.rb
@@ -32,7 +32,7 @@ module Pod
       register Sinatra::Twitter::Bootstrap::Assets
 
       get '/' do
-        redirect to('/log_messages')
+        redirect to('/disputes?scope=unsettled')
       end
 
       get '/commits' do


### PR DESCRIPTION
Accidentally loading this page now causes a very large amount of emails to admins. So I'm avoiding it for now.