### PR TITLE
Ensure that all models ‘scope’ to a lazy dataset

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,6 @@ GEM
       activesupport (>= 4.0.2)
       fuzzy_match (~> 2.0.4)
       nap (~> 1.0)
-    concurrent-ruby (1.0.2)
     daemons (1.1.9)
     dalli (2.7.5)
     dotenv (0.7.0)

--- a/config/init.rb
+++ b/config/init.rb
@@ -84,6 +84,14 @@ DB = Sequel.connect(ENV['DATABASE_URL'], :loggers => db_loggers)
 DB.timezone = :utc
 Sequel.extension :core_extensions, :migration
 
+module Sequel
+  class Model
+    class << self
+      alias_method :scoped, :dataset
+    end
+  end
+end
+
 class << DB
   # Save point is needed in testing, because tests already run in a
   # transaction, which means the transaction would be re-used and we can't test


### PR DESCRIPTION
peiji-san will automatically call ‘all’ when using the ‘page’ method. This would cause all records to be eagerly loaded. This ensures that ‘all’ won’t be called, and instead a lazy accessor will be used

Closes #193. \c @alloy @orta 