### PR TITLE
Use a 200 when a pod is deleted instead of redirecting to a non-existent resource

### DIFF
--- a/app/controllers/api/pods_controller.rb
+++ b/app/controllers/api/pods_controller.rb
@@ -220,7 +220,8 @@ module Pod
         end
 
         response = version.delete!(@owner)
-        json_message(200, :deleted => true) if verify_github_responses!(response)
+        json_message(200, 'messages' => version.log_messages.map(&:public_attributes),
+                          'data_url' => version.data_url) if verify_github_responses!(response)
       end
 
       patch '/:name/owners', :requires_owner => true do

--- a/app/controllers/api/pods_controller.rb
+++ b/app/controllers/api/pods_controller.rb
@@ -220,7 +220,7 @@ module Pod
         end
 
         response = version.delete!(@owner)
-        redirect version.resource_path if verify_github_responses!(response)
+        json_message(200, :deleted => true) if verify_github_responses!(response)
       end
 
       patch '/:name/owners', :requires_owner => true do

--- a/spec/functional/api/pods_controller_spec.rb
+++ b/spec/functional/api/pods_controller_spec.rb
@@ -463,7 +463,7 @@ module Pod::TrunkApp
         delete @endpoint
       end.should.change { Commit.count }
       last_response.status.should == 200
-      json_response['deleted'].should == true
+      json_response['messages'].should == @version.log_messages.map(&:public_attributes)
       Pod.first(:name => spec.name).versions.map(&:deleted?).should == [true]
       Pod.first(:name => spec.name).versions.map { |v| v.last_published_by.specification_data }.should == ['{}']
     end

--- a/spec/functional/api/pods_controller_spec.rb
+++ b/spec/functional/api/pods_controller_spec.rb
@@ -462,8 +462,8 @@ module Pod::TrunkApp
       lambda do
         delete @endpoint
       end.should.change { Commit.count }
-      last_response.status.should == 302
-      last_response.location.should == 'https://example.org/AFNetworking/versions/1.2.0'
+      last_response.status.should == 200
+      json_response['deleted'].should == true
       Pod.first(:name => spec.name).versions.map(&:deleted?).should == [true]
       Pod.first(:name => spec.name).versions.map { |v| v.last_published_by.specification_data }.should == ['{}']
     end


### PR DESCRIPTION
Fixes https://github.com/CocoaPods/trunk.cocoapods.org/issues/168