### PR TITLE
Remove the check to see when a pod version was created to decide it's path on the Specs repo

### DIFF
--- a/app/models/pod_version.rb
+++ b/app/models/pod_version.rb
@@ -61,6 +61,11 @@ module Pod
         { 'name' => name, 'created_at' => created_at }
       end
 
+      # Where should it go in the current state of the repo
+      def current_destination_path
+        self.class.destination_path(pod.name, name, DateTime.now)
+      end
+
       def destination_path
         created_at = last_published_by.try(:created_at)
         self.class.destination_path(pod.name, name, created_at)

--- a/app/models/push_job.rb
+++ b/app/models/push_job.rb
@@ -53,7 +53,7 @@ module Pod
 
       def new_commit(update: false)
         self.class.github.create_new_commit(
-          pod_version.destination_path,
+          pod_version.current_destination_path,
           specification_data,
           commit_message,
           committer.name,
@@ -64,7 +64,7 @@ module Pod
 
       def delete_file
         self.class.github.delete_file_at_path(
-          pod_version.destination_path,
+          pod_version.current_destination_path,
           commit_message,
           committer.name,
           committer.email,

--- a/spec/unit/push_job_spec.rb
+++ b/spec/unit/push_job_spec.rb
@@ -35,7 +35,7 @@ module Pod::TrunkApp
 
       it 'creates a new commit in the spec repo and returns its sha' do
         response = response(201, { :commit => { :sha => fixture_new_commit_sha } }.to_json)
-        @github.stubs(:create_new_commit).with(@version.destination_path,
+        @github.stubs(:create_new_commit).with(@version.current_destination_path,
                                                @job.specification_data,
                                                MESSAGE,
                                                'Appie',


### PR DESCRIPTION
I can see where the original intent was going, but in reality the Specs repo only is post-sharded, so checking whether it was created pre-sharding would mean that it would use the wrong path each time.

Fixes https://github.com/CocoaPods/trunk.cocoapods.org/issues/211