### PR TITLE
Revert "Use a 200 when a pod is deleted instead of redirecting to a non-existent resource"

### DIFF
--- a/app/controllers/api/pods_controller.rb
+++ b/app/controllers/api/pods_controller.rb
@@ -220,8 +220,7 @@ module Pod
         end
 
         response = version.delete!(@owner)
-        json_message(200, 'messages' => version.log_messages.map(&:public_attributes),
-                          'data_url' => version.data_url) if verify_github_responses!(response)
+        redirect version.resource_path if verify_github_responses!(response)
       end
 
       patch '/:name/owners', :requires_owner => true do

--- a/spec/functional/api/pods_controller_spec.rb
+++ b/spec/functional/api/pods_controller_spec.rb
@@ -462,8 +462,8 @@ module Pod::TrunkApp
       lambda do
         delete @endpoint
       end.should.change { Commit.count }
-      last_response.status.should == 200
-      json_response['messages'].should == @version.log_messages.map(&:public_attributes)
+      last_response.status.should == 302
+      last_response.location.should == 'https://example.org/AFNetworking/versions/1.2.0'
       Pod.first(:name => spec.name).versions.map(&:deleted?).should == [true]
       Pod.first(:name => spec.name).versions.map { |v| v.last_published_by.specification_data }.should == ['{}']
     end


### PR DESCRIPTION
Reverts CocoaPods/trunk.cocoapods.org#206

Didn't work, this response has to redirect to something - not give the right JSON