### PR TITLE
Adds a slack notification when a dispute is resolved

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ group :development do
 
   # Only needed for importing existing spec repo data into DB.
   gem 'rugged'
+  gem 'pry'
 
   gem 'sinatra-contrib'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,6 +22,7 @@ GEM
       activesupport (>= 4.0.2, < 5)
       fuzzy_match (~> 2.0.4)
       nap (~> 1.0)
+    coderay (1.1.1)
     daemons (1.1.9)
     dalli (2.7.5)
     dotenv (0.7.0)
@@ -45,6 +46,7 @@ GEM
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
     metaclass (0.0.4)
+    method_source (0.8.2)
     mime-types (1.25.1)
     mini_portile (0.6.2)
     minitest (5.9.1)
@@ -65,6 +67,10 @@ GEM
     powerpack (0.1.1)
     prettybacon (0.0.2)
       bacon (~> 1.2)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
     rack (1.5.2)
     rack-attack (4.3.1)
       rack
@@ -110,6 +116,7 @@ GEM
     slim (1.3.9)
       temple (~> 0.6.3)
       tilt (~> 1.3, >= 1.3.3)
+    slop (3.6.0)
     temple (0.6.7)
     terminal-table (1.4.5)
     thin (1.6.2)
@@ -145,6 +152,7 @@ DEPENDENCIES
   peiji-san!
   pg
   prettybacon
+  pry
   rack-attack (~> 4.3.1)
   rack-ssl
   rack-test
@@ -167,4 +175,4 @@ RUBY VERSION
    ruby 2.1.3p242
 
 BUNDLED WITH
-   1.13.5
+   1.13.6

--- a/app/controllers/manage_controller.rb
+++ b/app/controllers/manage_controller.rb
@@ -1,6 +1,7 @@
 require 'app/controllers/html_controller'
 require 'app/helpers/manage_helper'
 require 'app/models/pod'
+require 'app/controllers/slack_controller'
 
 require 'active_support/core_ext/hash/except'
 require 'peiji_san/view_helper'
@@ -126,6 +127,7 @@ module Pod
       put '/disputes/:id' do
         @dispute = Dispute.find(:id => params[:id])
         @dispute.update(params[:dispute])
+        SlackController.notify_slack_of_resolved_dispute(@dispute) if params[:dispute][:settled]
         redirect to("/disputes/#{@dispute.id}")
       end
     end

--- a/app/controllers/slack_controller.rb
+++ b/app/controllers/slack_controller.rb
@@ -1,0 +1,46 @@
+require 'app/controllers/slack_controller'
+
+module Pod
+  module TrunkApp
+    module SlackController
+      SLACK_API_URL = 'https://cocoapods.slack.com/services/hooks/' \
+        "incoming-webhook?token=#{ENV['SLACK_DISPUTE_TOKEN']}"
+
+      def self.notify_slack_of_new_dispute(dispute)
+        link = "https://trunk.cocoapods.org/manage/disputes/#{dispute.id}"
+        send_to_slack(:attachments => [{
+                        :fallback => "New dispute on trunk [Urgent]: <#{link}>",
+                        :pretext => "There's a new dispute on trunk [Urgent]: <#{link}>",
+                        :color => :warning,
+                        :fields => [{
+                          :title => 'Dispute by ' \
+                            "#{dispute.claimer.name} (#{dispute.claimer.email})",
+                          :value => dispute.message,
+                          :short => false,
+                        }],
+                      }])
+      end
+
+      def self.notify_slack_of_resolved_dispute(dispute)
+        link = "https://trunk.cocoapods.org/manage/disputes/#{dispute.id}"
+        send_to_slack(:attachments => [{
+                        :fallback => "Settled dispute on trunk: <#{link}>",
+                        :pretext => "There's a settled dispute on trunk: <#{link}>",
+                        :color => :warning,
+                        :fields => [{
+                          :title => 'Dispute by ' \
+                            "#{dispute.claimer.name} (#{dispute.claimer.email})",
+                          :value => 'Settled',
+                          :short => false,
+                        }],
+                      }])
+      end
+
+      def self.send_to_slack(data)
+        REST.post(SLACK_API_URL, data.to_json)
+      rescue REST::Error
+        "RuboCop: If REST has problems POSTing to Slack, we don't care."
+      end
+    end
+  end
+end

--- a/spec/functional/manage_controller_spec.rb
+++ b/spec/functional/manage_controller_spec.rb
@@ -135,9 +135,9 @@ module Pod::TrunkApp
     end
 
     it 'updates a dispute' do
-      put "/disputes/#{@disputes.first.id}", :dispute => { :settled => true }
+      put "/disputes/#{@disputes.first.id}", :dispute => { :message => 'HELLO' }
       last_response.status.should == 302
-      @disputes.first.reload.should.be.settled
+      @disputes.first.reload.message.should == 'HELLO'
     end
   end
 


### PR DESCRIPTION
Fixes social issues, it's hard to know if a dispute has been resolved from just our chat room. If I go away for a while no-one really knows if I'm not doing the disputes so they just kinda get abandoned till I remember. Now people can see that nothing has happened.