### PR TITLE
Add a check for 1.3.0 + test specs and reject pods

### DIFF
--- a/app/controllers/api/pods_controller.rb
+++ b/app/controllers/api/pods_controller.rb
@@ -113,6 +113,13 @@ module Pod
                       'your version of CocoaPods to push this specification.'
             json_error(422, message)
           end
+
+          if Version.new(version[1]) == Version.new('1.3.0')
+            message = 'Due to a bug in CocoaPods 1.3.0, ' \
+                      'we have blocked this release from releasing to trunk. ' \
+                      'Please upgrade to 1.3.1 or higher, and re-submit.'
+            json_error(422, message)
+          end
         end
 
         specification = SpecificationWrapper.from_json(request.body.read)

--- a/spec/functional/api/pods_controller_spec.rb
+++ b/spec/functional/api/pods_controller_spec.rb
@@ -101,6 +101,15 @@ module Pod::TrunkApp
       json_response['error'].should.match /minimum CocoaPods version/
     end
 
+    it 'fails when the client CocoaPods version is 1.3.0 and the JSON includes the attribute "test_specs"' do
+      lambda do
+        post '/', spec.to_json, 'User-Agent' => 'CocoaPods/1.3.0'
+      end.should.not.change { Pod.count + PodVersion.count }
+
+      last_response.status.should == 422
+      json_response['error'].should.match /Please upgrade/
+    end
+
     it 'fails with a spec that does not pass a quick lint' do
       spec.name = nil
       spec.version = nil


### PR DESCRIPTION
The tests failing right now are wrong, because it's a blanket ban on 1.3.0 -  @dnkoutso got an opinion on the best way to check for the `test_specs` on the pod?