### PR TITLE
Add buddybuild's cocoadocs webhook endpoint

### DIFF
--- a/config/init.rb
+++ b/config/init.rb
@@ -53,6 +53,7 @@ if ENV['WEBHOOKS_ENABLED'] == 'true'
     "http://search.cocoapods.org#{hook_path}",
     "http://aws-search.cocoapods.org#{hook_path}",
     "http://metrics.cocoapods.org#{hook_path}",
+    "https://cocoadocs.buddybuild.com#{hook_path}",
   ]
 
   Webhook.enable


### PR DESCRIPTION
Hi there! 

Sorry it took so long, but the web-hook handler is ready to handle. We'd like to casually add it to the list of endpoints, watch how it goes and finally make the switch.

Let me know if there is anything else we need to do to start processing this doc!

I'm guessing I'll need the `OUTGOING_HOOK_PATH` from you?