### PR TITLE
Update webhooks to the real CocoaDocs IP

### DIFF
--- a/config/init.rb
+++ b/config/init.rb
@@ -49,7 +49,9 @@ if ENV['WEBHOOKS_ENABLED'] == 'true'
   Webhook.version_created = [
   ]
   Webhook.spec_updated = [
-    "http://api.cocoadocs.org:4567#{hook_path}",
+    # This is the Mac mini that used to be be CocoaDocs
+    # but now just runs README/Stats
+    "http://199.19.84.242:4567#{hook_path}",
     "http://search.cocoapods.org#{hook_path}",
     "http://aws-search.cocoapods.org#{hook_path}",
     "http://metrics.cocoapods.org#{hook_path}",


### PR DESCRIPTION
In giving the DNS to BudduyBuild, `api.cocoadocs.org` was passed over too and so the web hooks for CocoaPods.org broke - this adds the webhooks back so CHANGELOG/READMES can be updated.