### PR TITLE
Adds the metadata service to the webhooks

### DIFF
--- a/config/init.rb
+++ b/config/init.rb
@@ -56,6 +56,7 @@ if ENV['WEBHOOKS_ENABLED'] == 'true'
     "http://aws-search.cocoapods.org#{hook_path}",
     "http://metrics.cocoapods.org#{hook_path}",
     "https://cocoadocs.buddybuild.com#{hook_path}",
+    "https://cocoapods-metadata-service.herokuapp.com/webhook/#{hook_path}",
   ]
 
   Webhook.enable


### PR DESCRIPTION
This means that READMEs for GitHub OSS projects will be updated via a Heroku app instead of the mac mini for CocoaDocs. See https://github.com/CocoaPods/cocoapods-metadata-service