### PR TITLE
Add a migration for pod_versions

### DIFF
--- a/db/migrations/013_add_deleted_to_pod_versions.rb
+++ b/db/migrations/013_add_deleted_to_pod_versions.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  change do
+    alter_table :pod_versions do
+      add_column :deleted, :boolean, :default => false
+    end
+  end
+end

--- a/db/schema.txt
+++ b/db/schema.txt
@@ -5,14 +5,6 @@ schema_info
 | version | 23  | "integer" | "0"     | false      | false       | :integer | 0            |
 +---------+-----+-----------+---------+------------+-------------+----------+--------------+
 
-owners_pods
-+----------+-----+-----------+---------+------------+-------------+----------+--------------+
-| name     | oid | db_type   | default | allow_null | primary_key | type     | ruby_default |
-+----------+-----+-----------+---------+------------+-------------+----------+--------------+
-| owner_id | 23  | "integer" | nil     | false      | true        | :integer | nil          |
-| pod_id   | 23  | "integer" | nil     | false      | true        | :integer | nil          |
-+----------+-----+-----------+---------+------------+-------------+----------+--------------+
-
 sessions
 +--------------------+------+-------------------------------+----------------------------------------+------------+-------------+-----------+--------------+
 | name               | oid  | db_type                       | default                                | allow_null | primary_key | type      | ruby_default |
@@ -41,16 +33,29 @@ pods
 | deleted         | 16   | "boolean"                     | "false"                            | true       | false       | :boolean  | false        |
 +-----------------+------+-------------------------------+------------------------------------+------------+-------------+-----------+--------------+
 
-pod_versions
-+------------+------+-------------------------------+--------------------------------------------+------------+-------------+-----------+--------------+
-| name       | oid  | db_type                       | default                                    | allow_null | primary_key | type      | ruby_default |
-+------------+------+-------------------------------+--------------------------------------------+------------+-------------+-----------+--------------+
-| id         | 23   | "integer"                     | "nextval('pod_versions_id_seq'::regclass)" | false      | true        | :integer  | nil          |
-| name       | 1043 | "character varying(255)"      | nil                                        | false      | false       | :string   | nil          |
-| created_at | 1114 | "timestamp without time zone" | nil                                        | true       | false       | :datetime | nil          |
-| updated_at | 1114 | "timestamp without time zone" | nil                                        | true       | false       | :datetime | nil          |
-| pod_id     | 23   | "integer"                     | nil                                        | false      | false       | :integer  | nil          |
-+------------+------+-------------------------------+--------------------------------------------+------------+-------------+-----------+--------------+
+owners_pods
++----------+-----+-----------+---------+------------+-------------+----------+--------------+
+| name     | oid | db_type   | default | allow_null | primary_key | type     | ruby_default |
++----------+-----+-----------+---------+------------+-------------+----------+--------------+
+| owner_id | 23  | "integer" | nil     | false      | true        | :integer | nil          |
+| pod_id   | 23  | "integer" | nil     | false      | true        | :integer | nil          |
++----------+-----+-----------+---------+------------+-------------+----------+--------------+
+
+commits
++----------------------------+------+-------------------------------+---------------------------------------+------------+-------------+-----------+--------------+
+| name                       | oid  | db_type                       | default                               | allow_null | primary_key | type      | ruby_default |
++----------------------------+------+-------------------------------+---------------------------------------+------------+-------------+-----------+--------------+
+| id                         | 23   | "integer"                     | "nextval('commits_id_seq'::regclass)" | false      | true        | :integer  | nil          |
+| specification_data         | 25   | "text"                        | nil                                   | false      | false       | :string   | nil          |
+| sha                        | 1043 | "character varying(255)"      | nil                                   | false      | false       | :string   | nil          |
+| created_at                 | 1114 | "timestamp without time zone" | nil                                   | true       | false       | :datetime | nil          |
+| updated_at                 | 1114 | "timestamp without time zone" | nil                                   | true       | false       | :datetime | nil          |
+| pod_version_id             | 23   | "integer"                     | nil                                   | false      | false       | :integer  | nil          |
+| committer_id               | 23   | "integer"                     | nil                                   | false      | false       | :integer  | nil          |
+| imported                   | 16   | "boolean"                     | "false"                               | true       | false       | :boolean  | false        |
+| renamed_file_during_import | 16   | "boolean"                     | "false"                               | true       | false       | :boolean  | false        |
+| deleted_file_during_import | 16   | "boolean"                     | "false"                               | true       | false       | :boolean  | false        |
++----------------------------+------+-------------------------------+---------------------------------------+------------+-------------+-----------+--------------+
 
 disputes
 +------------+------+-------------------------------+----------------------------------------+------------+-------------+-----------+--------------+
@@ -90,19 +95,15 @@ owners
 | updated_at | 1114 | "timestamp without time zone" | nil                                  | true       | false       | :datetime | nil          |
 +------------+------+-------------------------------+--------------------------------------+------------+-------------+-----------+--------------+
 
-commits
-+----------------------------+------+-------------------------------+---------------------------------------+------------+-------------+-----------+--------------+
-| name                       | oid  | db_type                       | default                               | allow_null | primary_key | type      | ruby_default |
-+----------------------------+------+-------------------------------+---------------------------------------+------------+-------------+-----------+--------------+
-| id                         | 23   | "integer"                     | "nextval('commits_id_seq'::regclass)" | false      | true        | :integer  | nil          |
-| specification_data         | 25   | "text"                        | nil                                   | false      | false       | :string   | nil          |
-| sha                        | 1043 | "character varying(255)"      | nil                                   | false      | false       | :string   | nil          |
-| created_at                 | 1114 | "timestamp without time zone" | nil                                   | true       | false       | :datetime | nil          |
-| updated_at                 | 1114 | "timestamp without time zone" | nil                                   | true       | false       | :datetime | nil          |
-| pod_version_id             | 23   | "integer"                     | nil                                   | false      | false       | :integer  | nil          |
-| committer_id               | 23   | "integer"                     | nil                                   | false      | false       | :integer  | nil          |
-| imported                   | 16   | "boolean"                     | "false"                               | true       | false       | :boolean  | false        |
-| renamed_file_during_import | 16   | "boolean"                     | "false"                               | true       | false       | :boolean  | false        |
-| deleted_file_during_import | 16   | "boolean"                     | "false"                               | true       | false       | :boolean  | false        |
-+----------------------------+------+-------------------------------+---------------------------------------+------------+-------------+-----------+--------------+
+pod_versions
++------------+------+-------------------------------+--------------------------------------------+------------+-------------+-----------+--------------+
+| name       | oid  | db_type                       | default                                    | allow_null | primary_key | type      | ruby_default |
++------------+------+-------------------------------+--------------------------------------------+------------+-------------+-----------+--------------+
+| id         | 23   | "integer"                     | "nextval('pod_versions_id_seq'::regclass)" | false      | true        | :integer  | nil          |
+| name       | 1043 | "character varying(255)"      | nil                                        | false      | false       | :string   | nil          |
+| created_at | 1114 | "timestamp without time zone" | nil                                        | true       | false       | :datetime | nil          |
+| updated_at | 1114 | "timestamp without time zone" | nil                                        | true       | false       | :datetime | nil          |
+| pod_id     | 23   | "integer"                     | nil                                        | false      | false       | :integer  | nil          |
+| deleted    | 16   | "boolean"                     | "false"                                    | true       | false       | :boolean  | false        |
++------------+------+-------------------------------+--------------------------------------------+------------+-------------+-----------+--------------+
 


### PR DESCRIPTION
I started up this repo from scratch and was surprised to find that the schema locally doesn't match the schema in prod, basically `pod_version` has a `deleted` column in prod

<img width="818" alt="screen shot 2019-01-05 at 1 34 38 pm" src="https://user-images.githubusercontent.com/49038/50727851-e9a9f000-10ee-11e9-8e9c-42308f279823.png">

But it's not got in there via a migration, and you can't run `rake db:bootstrap RACK_ENV=test` because code depends on it. 

Weird.