### PR TITLE
Update cocoapods-core to 1.7.0.rc.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 sudo: false
 language: ruby
 before_script: .travis/before.sh
-install: 
-  - gem install bundler
+install:
+  - gem install bundler -v "~> 1.17"
   - bundle install --deployment --without development production
 rvm: 2.5.1
 cache: bundler

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GEM
       parser (~> 2.2)
     backports (3.6.0)
     bacon (1.2.0)
-    cocoapods-core (1.7.0.beta.3)
+    cocoapods-core (1.7.0.rc.2)
       activesupport (>= 4.0.2, < 6)
       fuzzy_match (~> 2.0.4)
       nap (~> 1.0)

--- a/app/controllers/api/pods_controller.rb
+++ b/app/controllers/api/pods_controller.rb
@@ -107,17 +107,26 @@ module Pod
         verify_pushes_allowed!
 
         if version = %r{CocoaPods/([0-9a-z\.]+)}i.match(env['User-Agent'])
-          if Version.new(version[1]) < MINIMUM_COCOAPODS_VERSION
+          publishing_version = Version.new(version[1])
+          if publishing_version < MINIMUM_COCOAPODS_VERSION
             message = 'The minimum CocoaPods version allowed to push new ' \
                       "specs is `#{MINIMUM_COCOAPODS_VERSION}`. Please update " \
                       'your version of CocoaPods to push this specification.'
             json_error(422, message)
           end
 
-          if Version.new(version[1]) == Version.new('1.3.0')
+          if publishing_version == Version.new('1.3.0')
             message = 'Due to a bug in CocoaPods 1.3.0, ' \
                       'we have blocked this release from releasing to trunk. ' \
                       'Please upgrade to 1.3.1 or higher, and re-submit.'
+            json_error(422, message)
+          end
+
+          if publishing_version.major === 1 && publishing_version.minor === 7 &&
+              publishing_version <= Version.new('1.7.0.rc.1')
+            message = 'Due to a bug in CocoaPods 1.7.0.rc1, ' \
+                      'we have blocked this release from releasing to trunk. ' \
+                      'Please upgrade to 1.7.0.rc.2 or higher, and re-submit.'
             json_error(422, message)
           end
         end

--- a/app/controllers/api/pods_controller.rb
+++ b/app/controllers/api/pods_controller.rb
@@ -122,10 +122,10 @@ module Pod
             json_error(422, message)
           end
 
-          if publishing_version.major === 1 && publishing_version.minor === 7 &&
+          if publishing_version.major == 1 && publishing_version.minor == 7 &&
               publishing_version <= Version.new('1.7.0.rc.1')
-            message = 'Due to a bug in CocoaPods 1.7.0.rc1, ' \
-                      'we have blocked this release from releasing to trunk. ' \
+            message = 'Due to a bug in CocoaPods 1.7.0.rc.1, ' \
+                      'we have blocked this and earlier releases from releasing to trunk. ' \
                       'Please upgrade to 1.7.0.rc.2 or higher, and re-submit.'
             json_error(422, message)
           end

--- a/spec/functional/api/pods_controller_spec.rb
+++ b/spec/functional/api/pods_controller_spec.rb
@@ -110,6 +110,24 @@ module Pod::TrunkApp
       json_response['error'].should.match /Please upgrade/
     end
 
+    it 'fails when the client CocoaPods version is <= 1.7.0.rc.1 due to missing "swift_version" singular attribute' do
+      lambda do
+        post '/', spec.to_json, 'User-Agent' => 'CocoaPods/1.7.0.rc.1'
+      end.should.not.change { Pod.count + PodVersion.count }
+
+      last_response.status.should == 422
+      json_response['error'].should.match /Please upgrade/
+    end
+
+    it 'succeeds when the client CocoaPods version is earlier than 1.7 minor version' do
+      lambda do
+        post '/', spec.to_json, 'User-Agent' => 'CocoaPods/1.6.2'
+      end.should.change { Pod.count }
+
+      last_response.status.should == 302
+      last_response.location.should == 'https://example.org/AFNetworking/versions/1.2.0'
+    end
+
     it 'fails with a spec that does not pass a quick lint' do
       spec.name = nil
       spec.version = nil

--- a/spec/functional/api/pods_controller_spec.rb
+++ b/spec/functional/api/pods_controller_spec.rb
@@ -128,6 +128,15 @@ module Pod::TrunkApp
       last_response.location.should == 'https://example.org/AFNetworking/versions/1.2.0'
     end
 
+    it 'succeeds when the client CocoaPods version is later than 1.7.0.rc.1 version' do
+      lambda do
+        post '/', spec.to_json, 'User-Agent' => 'CocoaPods/1.7.0.rc.2'
+      end.should.change { Pod.count }
+
+      last_response.status.should == 302
+      last_response.location.should == 'https://example.org/AFNetworking/versions/1.2.0'
+    end
+
     it 'fails with a spec that does not pass a quick lint' do
       spec.name = nil
       spec.version = nil


### PR DESCRIPTION
Also prevents 1.7.x versions <= 1.7.0.rc.1 from publishing due to https://github.com/CocoaPods/CocoaPods/issues/8635 bug.