### PR TITLE
Transactional emails for adding/deleting/deprecating

### DIFF
--- a/app/controllers/api/pods_controller.rb
+++ b/app/controllers/api/pods_controller.rb
@@ -185,7 +185,7 @@ module Pod
 
         response = version.push!(@owner, specification.to_pretty_json, 'Add')
 
-        pod.owners.each { |owner| 
+        pod.owners.each do |owner|
           deployer_email = @owner.email
 
           mail = Mail.new
@@ -195,7 +195,7 @@ module Pod
           mail.subject = '[CocoaPods] #{pod.name}@#{version.name} was released.'
           mail.body    = ERB.new(File.read(File.join(ROOT, 'app/views/mailer/new_version.erb'))).result(binding)
           mail.deliver
-        }
+        end
 
         redirect url(version.resource_path) if verify_github_responses!(response)
       end
@@ -227,7 +227,7 @@ module Pod
           json_error(422, 'There were no published versions to deprecate.')
         end
 
-        pod.owners.each { |owner|
+        pod.owners.each do |owner|
           deprecator_email = @owner.email
 
           mail = Mail.new
@@ -237,7 +237,7 @@ module Pod
           mail.subject = '[CocoaPods] #{pod.name} was deprecated.'
           mail.body    = ERB.new(File.read(File.join(ROOT, 'app/views/mailer/deprecated.erb'))).result(binding)
           mail.deliver
-        }
+        end
 
         redirect pod.versions.last.resource_path if verify_github_responses!(responses)
       end
@@ -262,7 +262,7 @@ module Pod
 
         response = version.delete!(@owner)
 
-        pod.owners.each { |owner|
+        pod.owners.each do |owner|
           deletor_email = @owner.email
 
           mail = Mail.new
@@ -272,7 +272,7 @@ module Pod
           mail.subject = '[CocoaPods] #{pod.name}@#{version.name} was deleted.'
           mail.body    = ERB.new(File.read(File.join(ROOT, 'app/views/mailer/deleted.erb'))).result(binding)
           mail.deliver
-        }
+        end
 
         redirect version.resource_path if verify_github_responses!(response)
       end

--- a/app/controllers/api/pods_controller.rb
+++ b/app/controllers/api/pods_controller.rb
@@ -184,20 +184,23 @@ module Pod
         end
 
         response = version.push!(@owner, specification.to_pretty_json, 'Add')
+        if verify_github_responses!(response)
+          pod.owners.each do |owner|
+            deployer_email = @owner.email
+            commit_sha = JSON.parse(response.body)['commit']['sha']
+            commit_url = "https://github.com/#{ENV['GH_REPO']}/commit/#{commit_sha}"
 
-        pod.owners.each do |owner|
-          deployer_email = @owner.email
+            mail = Mail.new
+            mail.charset = 'UTF-8'
+            mail.from    = 'no-reply@cocoapods.org'
+            mail.to      = owner.email
+            mail.subject = '[CocoaPods] #{pod.name}@#{version.name} was released.'
+            mail.body    = ERB.new(File.read(File.join(ROOT, 'app/views/mailer/new_version.erb'))).result(binding)
+            mail.deliver
+          end
 
-          mail = Mail.new
-          mail.charset = 'UTF-8'
-          mail.from    = 'no-reply@cocoapods.org'
-          mail.to      = owner.email
-          mail.subject = '[CocoaPods] #{pod.name}@#{version.name} was released.'
-          mail.body    = ERB.new(File.read(File.join(ROOT, 'app/views/mailer/new_version.erb'))).result(binding)
-          mail.deliver
+          redirect url(version.resource_path)
         end
-
-        redirect url(version.resource_path) if verify_github_responses!(response)
       end
 
       patch '/:name/deprecated', :requires_owner => true do
@@ -227,19 +230,21 @@ module Pod
           json_error(422, 'There were no published versions to deprecate.')
         end
 
-        pod.owners.each do |owner|
-          deprecator_email = @owner.email
+        if verify_github_responses!(responses)
+          pod.owners.each do |owner|
+            deprecator_email = @owner.email
 
-          mail = Mail.new
-          mail.charset = 'UTF-8'
-          mail.from    = 'no-reply@cocoapods.org'
-          mail.to      = owner.email
-          mail.subject = '[CocoaPods] #{pod.name} was deprecated.'
-          mail.body    = ERB.new(File.read(File.join(ROOT, 'app/views/mailer/deprecated.erb'))).result(binding)
-          mail.deliver
+            mail = Mail.new
+            mail.charset = 'UTF-8'
+            mail.from    = 'no-reply@cocoapods.org'
+            mail.to      = owner.email
+            mail.subject = '[CocoaPods] #{pod.name} was deprecated.'
+            mail.body    = ERB.new(File.read(File.join(ROOT, 'app/views/mailer/deprecated.erb'))).result(binding)
+            mail.deliver
+          end
+
+          redirect pod.versions.last.resource_path
         end
-
-        redirect pod.versions.last.resource_path if verify_github_responses!(responses)
       end
 
       delete '/:name/:version', :requires_owner => true do
@@ -261,20 +266,23 @@ module Pod
         end
 
         response = version.delete!(@owner)
+        if verify_github_responses!(response)
+          pod.owners.each do |owner|
+            deletor_email = @owner.email
+            commit_sha = JSON.parse(response.body)['commit']['sha']
+            commit_url = "https://github.com/#{ENV['GH_REPO']}/commit/#{commit_sha}"
 
-        pod.owners.each do |owner|
-          deletor_email = @owner.email
+            mail = Mail.new
+            mail.charset = 'UTF-8'
+            mail.from    = 'no-reply@cocoapods.org'
+            mail.to      = owner.email
+            mail.subject = '[CocoaPods] #{pod.name}@#{version.name} was deleted.'
+            mail.body    = ERB.new(File.read(File.join(ROOT, 'app/views/mailer/deleted.erb'))).result(binding)
+            mail.deliver
+          end
 
-          mail = Mail.new
-          mail.charset = 'UTF-8'
-          mail.from    = 'no-reply@cocoapods.org'
-          mail.to      = owner.email
-          mail.subject = '[CocoaPods] #{pod.name}@#{version.name} was deleted.'
-          mail.body    = ERB.new(File.read(File.join(ROOT, 'app/views/mailer/deleted.erb'))).result(binding)
-          mail.deliver
+          redirect version.resource_path
         end
-
-        redirect version.resource_path if verify_github_responses!(response)
       end
 
       patch '/:name/owners', :requires_owner => true do

--- a/app/controllers/api/pods_controller.rb
+++ b/app/controllers/api/pods_controller.rb
@@ -184,6 +184,19 @@ module Pod
         end
 
         response = version.push!(@owner, specification.to_pretty_json, 'Add')
+
+        pod.owners.each { |owner| 
+          deployer_email = @owner.email
+
+          mail = Mail.new
+          mail.charset = 'UTF-8'
+          mail.from    = 'no-reply@cocoapods.org'
+          mail.to      = owner.email
+          mail.subject = '[CocoaPods] #{pod.name}@#{version.name} was released.'
+          mail.body    = ERB.new(File.read(File.join(ROOT, 'app/views/mailer/new_version.erb'))).result(binding)
+          mail.deliver
+        }
+
         redirect url(version.resource_path) if verify_github_responses!(response)
       end
 
@@ -214,6 +227,18 @@ module Pod
           json_error(422, 'There were no published versions to deprecate.')
         end
 
+        pod.owners.each { |owner|
+          deprecator_email = @owner.email
+
+          mail = Mail.new
+          mail.charset = 'UTF-8'
+          mail.from    = 'no-reply@cocoapods.org'
+          mail.to      = owner.email
+          mail.subject = '[CocoaPods] #{pod.name} was deprecated.'
+          mail.body    = ERB.new(File.read(File.join(ROOT, 'app/views/mailer/deprecated.erb'))).result(binding)
+          mail.deliver
+        }
+
         redirect pod.versions.last.resource_path if verify_github_responses!(responses)
       end
 
@@ -236,6 +261,19 @@ module Pod
         end
 
         response = version.delete!(@owner)
+
+        pod.owners.each { |owner|
+          deletor_email = @owner.email
+
+          mail = Mail.new
+          mail.charset = 'UTF-8'
+          mail.from    = 'no-reply@cocoapods.org'
+          mail.to      = owner.email
+          mail.subject = '[CocoaPods] #{pod.name}@#{version.name} was deleted.'
+          mail.body    = ERB.new(File.read(File.join(ROOT, 'app/views/mailer/deleted.erb'))).result(binding)
+          mail.deliver
+        }
+
         redirect version.resource_path if verify_github_responses!(response)
       end
 

--- a/app/views/mailer/deleted.erb
+++ b/app/views/mailer/deleted.erb
@@ -1,6 +1,6 @@
 Hi <%= owner.name %>,
 
-Version <%= version.name %> of <%= pod.name %> was deleted by <%= deletor_email %>. 
+Version <%= version.name %> of <%= pod.name %> <a href="<%= response.commit.html_url %>">was deleted<a/> by <%= deletor_email %>.
 
 Kind regards,
 the CocoaPods team

--- a/app/views/mailer/deleted.erb
+++ b/app/views/mailer/deleted.erb
@@ -1,6 +1,6 @@
 Hi <%= owner.name %>,
 
-Version <%= version.name %> of <%= pod_name %> was deleted by <%= deletor_email %>. 
+Version <%= version.name %> of <%= pod.name %> was deleted by <%= deletor_email %>. 
 
 Kind regards,
 the CocoaPods team

--- a/app/views/mailer/deleted.erb
+++ b/app/views/mailer/deleted.erb
@@ -1,6 +1,6 @@
 Hi <%= owner.name %>,
 
-Version <%= version.name %> of <%= pod.name %> <a href="<%= response.commit.html_url %>">was deleted<a/> by <%= deletor_email %>.
+Version <%= version.name %> of <%= pod.name %> <a href="<%= commit_url %>">was deleted<a/> by <%= deletor_email %>.
 
 Kind regards,
 the CocoaPods team

--- a/app/views/mailer/deleted.erb
+++ b/app/views/mailer/deleted.erb
@@ -1,0 +1,6 @@
+Hi <%= owner.name %>,
+
+Version <%= version.name %> of <%= pod_name %> was deleted by <%= deletor_email %>. 
+
+Kind regards,
+the CocoaPods team

--- a/app/views/mailer/deprecated.erb
+++ b/app/views/mailer/deprecated.erb
@@ -1,0 +1,6 @@
+Hi <%= owner.name %>,
+
+<%= pod.name %> was marked as deprecated by <%= deprecator_email %>. 
+
+Kind regards,
+the CocoaPods team

--- a/app/views/mailer/new_version.erb
+++ b/app/views/mailer/new_version.erb
@@ -1,0 +1,6 @@
+Hi <%= owner.name %>,
+
+A new version of <%= pod.name %> was released with version <%= version.name %> by <%= deployer_email %>
+
+Kind regards,
+the CocoaPods team

--- a/app/views/mailer/new_version.erb
+++ b/app/views/mailer/new_version.erb
@@ -1,6 +1,6 @@
 Hi <%= owner.name %>,
 
-A new version of <%= pod.name %> was released with version <%= version.name %> by <%= deployer_email %>
+A new version of <%= pod.name %> <a href="<%= response.commit.html_url %>">was released<a/> with version <%= version.name %> by <%= deployer_email %>
 
 Kind regards,
 the CocoaPods team

--- a/app/views/mailer/new_version.erb
+++ b/app/views/mailer/new_version.erb
@@ -1,6 +1,6 @@
 Hi <%= owner.name %>,
 
-A new version of <%= pod.name %> <a href="<%= response.commit.html_url %>">was released<a/> with version <%= version.name %> by <%= deployer_email %>
+A new version of <%= pod.name %> <a href="<%= commit_url %>">was released<a/> with version <%= version.name %> by <%= deployer_email %>
 
 Kind regards,
 the CocoaPods team


### PR DESCRIPTION
Most of the dependency managers I work with now ship an 'you've done a thing' email, we should probably be doing that too. Also includes https://github.com/CocoaPods/trunk.cocoapods.org/pull/304 in the commit history ATM