### PR TITLE
Add a 2nd 404 page

### DIFF
--- a/app/views/session_verification/html/not_found.slim
+++ b/app/views/session_verification/html/not_found.slim
@@ -1,0 +1,2 @@
+h2 Hello there, looks like this session has already been accepted.
+h3 ( Technically its a 404, but this is the most common case. )


### PR DESCRIPTION
This is what file is 'missing' in the error logs: https://github.com/CocoaPods/CocoaPods/issues/11271

I certainly didn't delete the [original 404 page](https://github.com/CocoaPods/trunk.cocoapods.org/blob/master/app/views/html/not_found.slim), but a more specific one is pretty useful anyway