### PR TITLE
Fix error rendering scss file

### DIFF
--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -81,7 +81,8 @@ module Pod
       # --- Assets ------------------------------------------------------------------------------
 
       get '/claims.css' do
-        scss :claims, :style => :expanded
+        options = { :style => :expanded, :default_content_type => :css, :layout => false }
+        render :scss, :claims, options
       end
 
       private

--- a/app/views/claims/claims.scss
+++ b/app/views/claims/claims.scss
@@ -1,5 +1,5 @@
 #trunk-content {
-  background-color:#d1c4c0;
+  background-color:#565656;
   margin-top: -260px;
   margin-bottom: 64px;
   color:white;


### PR DESCRIPTION
Sinatra 3.0.0 removed native support for `sass` / `scss` in https://github.com/sinatra/sinatra/pull/1768 so we need to manually implement it